### PR TITLE
Add provider unit test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,29 +1,68 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mr_collection/collection_app.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mr_collection/provider/user_provider.dart';
+import 'package:mr_collection/data/repository/member_repository.dart';
+import 'package:mr_collection/data/repository/event_repository.dart';
+import 'package:mr_collection/data/model/freezed/member.dart';
+import 'package:mr_collection/data/model/freezed/event.dart';
+import 'package:mr_collection/data/model/freezed/user.dart';
+import 'package:mr_collection/data/model/payment_status.dart';
+import 'package:mr_collection/services/user_service.dart';
+import 'package:mr_collection/data/repository/user_repository.dart';
+
+class FakeMemberRepository extends MemberRepository {
+  FakeMemberRepository() : super(baseUrl: '');
+  List<String>? receivedNames;
+  @override
+  Future<List<Member>> createMembers(
+      String userId, String eventId, List<String> newMemberNames) async {
+    receivedNames = newMemberNames;
+    return newMemberNames
+        .map((name) => Member(
+              memberId: 'id_\$name',
+              memberName: name,
+              status: PaymentStatus.unpaid,
+            ))
+        .toList();
+  }
+}
+
+class FakeEventRepository extends EventRepository {
+  FakeEventRepository() : super(baseUrl: '');
+}
+
+class FakeUserService extends UserService {
+  FakeUserService() : super(UserRepository(baseUrl: ''));
+}
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const CollectionApp());
+  group('UserNotifier.createMembers', () {
+    test('adds members returned by repository', () async {
+      final memberRepo = FakeMemberRepository();
+      final container = ProviderContainer(overrides: [
+        memberRepositoryProvider.overrideWithValue(memberRepo),
+        eventRepositoryProvider.overrideWithValue(FakeEventRepository()),
+        userServiceProvider.overrideWithValue(FakeUserService()),
+      ]);
+      addTearDown(container.dispose);
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+      final notifier = container.read(userProvider.notifier);
+      const event = Event(eventId: 'e1', eventName: 'event', members: []);
+      const user = User(
+        userId: 'u1',
+        appleId: null,
+        lineUserId: null,
+        paypayUrl: null,
+        belongingLineGroupIds: null,
+        events: [event],
+      );
+      notifier.state = user;
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+      await notifier.createMembers('u1', 'e1', 'Alice\nBob');
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+      final updatedMembers = notifier.state!.events.first.members;
+      expect(updatedMembers.map((m) => m.memberName).toList(), ['Alice', 'Bob']);
+      expect(memberRepo.receivedNames, ['Alice', 'Bob']);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- replace the template widget test with a provider test
- test that `UserNotifier.createMembers` forwards member names to the repository and updates state

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cbe7271908330b0501da92ff1b1f3