### PR TITLE
Fix duplicate icon asset

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,6 @@ flutter:
     - assets/icons/drawer_file.svg
     - assets/icons/drawer_envelope.svg
     - assets/icons/drawer_delete_account.svg
-    - assets/icons/ic_back.svg
     - assets/icons/ic_next.svg
 
   fonts:


### PR DESCRIPTION
## Summary
- remove duplicated `assets/icons/ic_back.svg` entry in `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccbecfb9483308051a17f6f356d7f