### PR TITLE
Implement message sending feature

### DIFF
--- a/lib/data/repository/event_repository.dart
+++ b/lib/data/repository/event_repository.dart
@@ -87,4 +87,23 @@ class EventRepository {
       throw Exception('イベントの削除に失敗しました');
     }
   }
+
+  Future<bool> sendMessage(
+      String userId, String eventId, String message) async {
+    final url = Uri.parse('$baseUrl/users/$userId/events/$eventId/message');
+
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'message': message}),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return data['isSuccessful'] as bool? ?? false;
+    } else {
+      debugPrint('メッセージ送信に失敗しました: ${response.statusCode}');
+      throw Exception('メッセージ送信に失敗しました');
+    }
+  }
 }

--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -305,4 +305,16 @@ class UserNotifier extends StateNotifier<User?> {
       debugPrint('メンバーの作成中にエラーが発生しました: $e : user_provider.dart');
     }
   }
+
+  Future<bool> sendMessage(
+      String userId, String eventId, String message) async {
+    try {
+      final result =
+          await eventRepository.sendMessage(userId, eventId, message);
+      return result;
+    } catch (e) {
+      debugPrint('メッセージ送信中にエラーが発生しました: $e');
+      return false;
+    }
+  }
 }

--- a/lib/ui/components/dialog/line_message_failed_dialog.dart
+++ b/lib/ui/components/dialog/line_message_failed_dialog.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class LineMessageFailedDialog extends StatelessWidget {
+  const LineMessageFailedDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(23)),
+      child: SizedBox(
+        width: 320,
+        height: 191,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              '送信に失敗しました',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'お手数ですが再度お試しください',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+            ),
+            const SizedBox(height: 30),
+            SizedBox(
+              height: 40,
+              width: 272,
+              child: ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFC5C5C5),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                child: Text(
+                  '閉じる',
+                  style: GoogleFonts.notoSansJp(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add API call to send message in `EventRepository`
- expose `sendMessage` through `UserNotifier`
- connect confirmation dialog to provider and show result dialogs
- create new failure dialog for message send errors

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540f46680c8330b30c77a40d44c760